### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,26 @@
+name: Playwright Tests
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      BASE_URL: https://www.kfc.com
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run tests
+        run: npm run e2e

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      BASE_URL: https://www.kfc.com
+      BASE_URL: https://www.qa.kfc-digital.io
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # playtime
+
 Playtime
+
+## Continuous Integration
+
+This repository uses **GitHub Actions** to run the Playwright test suite on each push and pull request. The workflow installs dependencies, installs the required browsers, and then executes `npm run e2e`.


### PR DESCRIPTION
## Summary
- run Playwright tests in GitHub Actions
- document CI in README

## Testing
- `npm ci`
- `npm run e2e` *(fails: 17 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6849ffea90a08321991e8290dc9516eb