### PR TITLE
Add project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
-# playtime
-Playtime
+# Playtime
+
+This project contains end-to-end tests written with [Playwright](https://playwright.dev/). The tests automate the KFC web site and demonstrate a Page Object Model approach.
+
+## Requirements
+
+- Node.js 18 or newer
+- npm
+
+## Setup
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Create a `.env` file (optional) to set environment variables used by the tests. The most important variable is `BASE_URL` which defines the base address for the site under test:
+
+```bash
+BASE_URL=https://www.kfc.com
+```
+
+If you plan to run the OTP login flow you will also need Google API credentials. See `lib/utils/gmailHelper.js` for the fields that can be configured via environment variables.
+
+## Running tests
+
+Execute all tests using Playwright:
+
+```bash
+npm run e2e
+```
+
+Test reports are written to `playwright-report/` and `test-results/` which are ignored by Git.
+
+## Repository structure
+
+```
+lib/            Page objects and shared utilities
+lib/locators/   JSON files with selectors used by the page objects
+lib/pages/      JavaScript classes representing pages
+lib/utils/      Helper modules (e.g. Gmail OTP fetcher)
+tests/          Playwright test suites
+```
+
+The `tests-examples` folder contains the default sample test provided by Playwright.
+
+## License
+
+This project is licensed under the terms of the `LICENSE` file in this repository.

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -1,0 +1,20 @@
+# Project Overview
+
+This document provides a quick reference for the important pieces of the Playtime test suite.
+
+## Playwright configuration
+
+The test runner is configured in `playwright.config.js`. Tests run in Chromium with video capture enabled. The `BASE_URL` environment variable controls the base address for page navigation.
+
+## Page objects
+
+The `lib/pages/` directory contains classes that represent sections of the KFC web site. Each page uses locators defined in `lib/locators/` to interact with the UI. Common functionality lives in `lib/pages/basePage.js`.
+
+## Gmail OTP helper
+
+`lib/utils/gmailHelper.js` fetches a one-time password from Gmail using Google OAuth credentials. When running locally, ensure the required OAuth values are supplied, either by editing the file or providing environment variables.
+
+## Adding tests
+
+Create new test files under `tests/` using the Playwright API. Page objects can be imported from `lib/pages`. For examples, see `tests/header.spec.js` and `tests/footer.spec.js`.
+


### PR DESCRIPTION
## Summary
- document how to set up and run the Playwright tests
- add a wiki page with details about configuration and page objects

## Testing
- `npm run e2e` *(fails: 17 failed)*

------
https://chatgpt.com/codex/tasks/task_e_684a013bd6d88321bb0ad5447e8bafa7