### PR TITLE
Fix Playwright headless mode on CI

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -52,8 +52,9 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'],
-      headless: false,  
+      use: {
+        ...devices['Desktop Chrome'],
+        headless: process.env.CI ? true : false,
       },
     },
 


### PR DESCRIPTION
## Summary
- ensure Playwright uses headless mode when running in GitHub Actions

## Testing
- `npm run e2e` *(fails: 17 failed)*

------
https://chatgpt.com/codex/tasks/task_e_684a030f23288321aa6a688b26f695b6